### PR TITLE
Fix message sender retrieval to support new Telegram `sender_chat` field

### DIFF
--- a/handlers/quote.js
+++ b/handlers/quote.js
@@ -299,8 +299,7 @@ module.exports = async (ctx, next) => {
       messageFrom = quoteMessage.forward_from_chat
     } else if (quoteMessage.forward_from) {
       messageFrom = quoteMessage.forward_from
-    } else if ([1087968824, 777000].includes(quoteMessage.from.id)) {
-      /* 1087968824 is id of @GroupAnonymousBot. This part swaps anon bot data to the chat data */
+    } else if (quoteMessage.sender_chat) {
       messageFrom = {
         id: quoteMessage.sender_chat.id,
         name: quoteMessage.sender_chat.title,
@@ -381,12 +380,21 @@ module.exports = async (ctx, next) => {
       if (replyMessageInfo.forward_from) {
         replyMessageInfo.from = replyMessageInfo.forward_from
       }
-      if (replyMessageInfo.from.first_name) message.replyMessage.name = replyMessageInfo.from.first_name
-      if (replyMessageInfo.from.last_name) message.replyMessage.name += ' ' + replyMessageInfo.from.last_name
-      if (replyMessageInfo.from.id) {
-        message.replyMessage.chatId = replyMessageInfo.from.id
+      if (replyMessageInfo.sender_chat) {
+        message.replyMessage.name = replyMessageInfo.sender_chat.title
+        if (replyMessageInfo.sender_chat.id) {
+          message.replyMessage.chatId = replyMessageInfo.sender_chat.id
+        } else {
+          message.replyMessage.chatId = hashCode(message.replyMessage.name)
+        }
       } else {
-        message.replyMessage.chatId = hashCode(message.replyMessage.name)
+        if (replyMessageInfo.from.first_name) message.replyMessage.name = replyMessageInfo.from.first_name
+        if (replyMessageInfo.from.last_name) message.replyMessage.name += ' ' + replyMessageInfo.from.last_name
+        if (replyMessageInfo.from.id) {
+          message.replyMessage.chatId = replyMessageInfo.from.id
+        } else {
+          message.replyMessage.chatId = hashCode(message.replyMessage.name)
+        }
       }
       if (replyMessageInfo.text) message.replyMessage.text = replyMessageInfo.text
       if (replyMessageInfo.caption) message.replyMessage.text = replyMessageInfo.caption


### PR DESCRIPTION
This update addresses the issue of retrieving the correct sender information for messages sent on behalf of a channel or by anonymous chat administrators. Previously, the bot relied on `message.from.first_name` to get the sender's name, which, due to Telegram's backward compatibility measures, resulted in a fake sender user name like "Channel" in non-channel chats:
https://core.telegram.org/bots/api#message

> **Field:** `from`
> **Type:** `User`
> **Description:** _Optional._ Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.


With this update, the bot now correctly uses the sender_chat field to get the actual chat title, ensuring that the correct sender information is used for generating quotes.